### PR TITLE
fixed detached sign/verify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1642,7 +1642,7 @@ function unpackneg(r, p) {
   return 0;
 }
 
-function crypto_sign_open(msg, sm, pk) {
+function crypto_sign_open(sm, msg, pk) {
   check(msg, sm.length - crypto_sign_BYTES)
   check(sm, crypto_sign_BYTES)
   check(pk, crypto_sign_PUBLICKEYBYTES)

--- a/index.js
+++ b/index.js
@@ -1601,7 +1601,7 @@ function crypto_sign(sm, m, sk) {
 function crypto_sign_detached(sig, m, sk) {
   var sm = new Uint8Array(m.length + crypto_sign_BYTES)
   crypto_sign(sm, m, sk)
-  for (var i = 0; i < 32; i++) sig[i] = sm[i]
+  for (var i = 0; i < crypto_sign_BYTES; i++) sig[i] = sm[i]
 }
 
 function unpackneg(r, p) {
@@ -1684,8 +1684,8 @@ function crypto_sign_verify_detached (sig, m, pk) {
   check(sig, crypto_sign_BYTES)
   var sm = new Uint8Array(m.length + sig.length)
   var i = 0
-  for (i = 0; i < 64; i++) sm[i] = m[i]
-  for (i = 0; i < m.length; i++) sm[i + 64] = m[i]
+  for (i = 0; i < crypto_sign_BYTES; i++) sm[i] = sig[i]
+  for (i = 0; i < m.length; i++) sm[i + crypto_sign_BYTES] = m[i]
   return crypto_sign_open(sm, m, pk)
 }
 


### PR DESCRIPTION
https://github.com/sodium-friends/sodium-javascript/blob/07e1bc4ed671d0ff8a46766c0204b6e15d99a386/index.js#L1689 expects the arguments of `crypto_sign_open` to be in a different order than they are