### PR TITLE
Add test for randombytes in web worker context

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "browser-run": "^4.0.2",
     "browserify": "^14.1.0",
-    "sodium-test": "^0.7.0"
+    "sodium-test": "^0.7.0",
+    "webworkify": "^1.4.0"
   },
   "scripts": {
     "browser": "browserify test.js | browser-run",

--- a/test-worker.js
+++ b/test-worker.js
@@ -1,0 +1,10 @@
+var sodium = require('.')
+
+module.exports = function (self) {
+  self.addEventListener('message', function (e) {
+    var arr = e.data[0]
+    sodium.randombytes_buf(arr)
+    self.postMessage(arr)
+    self.close()
+  })
+}

--- a/test.js
+++ b/test.js
@@ -1,3 +1,18 @@
 require('sodium-test')(require('.'))
 
-if (typeof window !== 'undefined') window.close()
+if (typeof window !== 'undefined') {
+  var test = require('tape')
+  var arrConst = new Uint8Array(16)
+  test('randombytes works in web worker context', function (t) {
+    var work = require('webworkify')
+    var w = work(require('./test-worker.js'))
+    w.addEventListener('message', function (e) {
+      var arr = e.data[0]
+      t.notEqual(arrConst, arr, '')
+      t.end()
+      window.close()
+    })
+    var arr = new Uint8Array(16)
+    w.postMessage([arr])
+  })
+}

--- a/test.js
+++ b/test.js
@@ -5,10 +5,10 @@ if (typeof window !== 'undefined') {
   var arrConst = new Uint8Array(16)
   test('randombytes works in web worker context', function (t) {
     var work = require('webworkify')
-    var w = work(require('./test-worker.js'))
+    var w = work(require('./tests/webworker.js'))
     w.addEventListener('message', function (e) {
       var arr = e.data[0]
-      t.notEqual(arrConst, arr, '')
+      t.notEqual(arrConst, arr, 'Array should contain random bytes')
       t.end()
       window.close()
     })

--- a/tests/webworker.js
+++ b/tests/webworker.js
@@ -1,4 +1,4 @@
-var sodium = require('.')
+var sodium = require('../')
 
 module.exports = function (self) {
   self.addEventListener('message', function (e) {


### PR DESCRIPTION
Fixes #9. 

For a while I considered whether or not we should test the entire `sodium-test` suite in web workers as well, but perhaps that unnecessary? I believe only the `randombytes` module differs in how it's run in browsers versus Node. Thanks for your consideration! I appreciate any input. 