### PR TITLE
In kdf, truncate key before passing to blake to match sodium-native behaviour

### DIFF
--- a/crypto_kdf.js
+++ b/crypto_kdf.js
@@ -6,7 +6,7 @@ module.exports.crypto_kdf_PRIMITIVE = 'blake2b'
 module.exports.crypto_kdf_BYTES_MIN = 16
 module.exports.crypto_kdf_BYTES_MAX = 64
 module.exports.crypto_kdf_CONTEXTBYTES = 8
-module.exports.crypto_kdf_KEYBYTES = 64
+module.exports.crypto_kdf_KEYBYTES = 32
 
 function STORE64_LE(dest, int) {
   var mul = 1
@@ -29,7 +29,7 @@ module.exports.crypto_kdf_derive_from_key = function crypto_kdf_derive_from_key 
   STORE64_LE(salt, subkey_id)
 
   var outlen = Math.min(subkey.length, module.exports.crypto_kdf_BYTES_MAX)
-  blake2b(outlen, key.slice(0, blake2b.KEYBYTES), salt, ctx_padded, true)
+  blake2b(outlen, key.subarray(0, module.exports.crypto_kdf_KEYBYTES), salt, ctx_padded, true)
     .final(subkey)
 }
 

--- a/crypto_kdf.js
+++ b/crypto_kdf.js
@@ -29,7 +29,7 @@ module.exports.crypto_kdf_derive_from_key = function crypto_kdf_derive_from_key 
   STORE64_LE(salt, subkey_id)
 
   var outlen = Math.min(subkey.length, module.exports.crypto_kdf_BYTES_MAX)
-  blake2b(outlen, key, salt, ctx_padded, true)
+  blake2b(outlen, key.slice(0, blake2b.KEYBYTES), salt, ctx_padded, true)
     .final(subkey)
 }
 


### PR DESCRIPTION
Currently, sodium-native and sodium-javascript are returning different
hashes. The code in hyperdrive passes a 64 byte secret key to the kdf,
but only 32 bytes are used by the native version, but all 64 bytes are
used in the javascript version. As a result, hyperdrive secret keys
can't be imported/exported across the two sodium implementations.

https://gist.github.com/jimpick/3e869522eddaad77ac1bc9e64f36e1a7

Fixes #11 