### PR TITLE
crypto_box_keypair

### DIFF
--- a/index.js
+++ b/index.js
@@ -1736,6 +1736,13 @@ function crypto_secretbox_open_easy(msg, box, n, k) {
   return true
 }
 
+function crypto_box_keypair(x, y) {
+  check(x, crypto_box_PUBLICKEYBYTES)
+  check(y, crypto_box_SECRETKEYBYTES)
+  randombytes(x, 32);
+  return crypto_scalarmult_base(y, x); 
+}
+
 var crypto_secretbox_KEYBYTES = 32,
     crypto_secretbox_NONCEBYTES = 24,
     crypto_secretbox_ZEROBYTES = 32,
@@ -1787,6 +1794,10 @@ sodium.crypto_secretbox_easy = crypto_secretbox_easy
 sodium.crypto_secretbox_open_easy = crypto_secretbox_open_easy
 sodium.crypto_secretbox_detached = crypto_secretbox_detached
 sodium.crypto_secretbox_open_detached = crypto_secretbox_open_detached
+
+sodium.crypto_box_PUBLICKEYBYTES = crypto_box_PUBLICKEYBYTES
+sodium.crypto_box_SECRETKEYBYTES = crypto_box_SECRETKEYBYTES
+sodium.crypto_box_keypair = crypto_box_keypair
 
 function cleanup(arr) {
   for (var i = 0; i < arr.length; i++) arr[i] = 0;

--- a/index.js
+++ b/index.js
@@ -1736,11 +1736,11 @@ function crypto_secretbox_open_easy(msg, box, n, k) {
   return true
 }
 
-function crypto_box_keypair(x, y) {
-  check(x, crypto_box_PUBLICKEYBYTES)
-  check(y, crypto_box_SECRETKEYBYTES)
-  randombytes(x, 32);
-  return crypto_scalarmult_base(y, x); 
+function crypto_box_keypair(pk, sk) {
+  check(pk, crypto_box_PUBLICKEYBYTES)
+  check(sk, crypto_box_SECRETKEYBYTES)
+  randombytes(pk, 32);
+  return crypto_scalarmult_base(sk, pk); 
 }
 
 var crypto_secretbox_KEYBYTES = 32,


### PR DESCRIPTION
This makes it easy for JS clients to generate public and secret keys for crypto_box_* which can be used with sodium-native or any other implementation.