### PR TITLE
react-native doesn't want crypto set to an empty module

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "browser": {
     "crypto": false
   },
+  "react-native": {
+    "crypto": "crypto"
+  },
   "scripts": {
     "browser": "browserify test.js | browser-run",
     "browser-manual": "browserify test.js | browser-run -p 1234",


### PR DESCRIPTION
This patch came from a conversation with @mafintosh, and is probably a useful provisional solution until sodium-native could be made to work on mobile devices.

React-Native is sort of like a browser, sort of a native environment. On react-native we don't have the browser's crypto implementation, so we need to require react-native-crypto. We can rewrite the module requirement to do that using the extraNodeModules feature in rn-cli.config.js, but the metro packager assumes that if there's a "browser" field in package.json that it's relevant to react-native libraries unless there's also a "react-native" field. Hurray.

Anyway, this silly little patch tells metro not to replace crypto with an empty module but actually to use whatever you currently have crypto set to (which is not solved here, so you'll still have to do that.)

This is necessary because randombytes.js does some complicated things to decide where to find a random bytes returning function and gets it wrong on react-native without this patch.