### PR TITLE
change to universal hashes

### DIFF
--- a/crypto_hash.js
+++ b/crypto_hash.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const sha512 = require('sha512-wasm')
+const sha512 = require('sha512-universal')
 const assert = require('nanoassert')
 
 if (new Uint16Array([1])[0] !== 1) throw new Error('Big endian architecture is not supported.')

--- a/crypto_hash_sha256.js
+++ b/crypto_hash_sha256.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const sha256 = require('sha256-wasm')
+const sha256 = require('sha256-universal')
 const assert = require('nanoassert')
 
 if (new Uint16Array([1])[0] !== 1) throw new Error('Big endian architecture is not supported.')

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "blake2b": "^2.1.1",
     "chacha20-universal": "^1.0.4",
     "nanoassert": "^2.0.0",
-    "sha256-wasm": "^1.3.0",
-    "sha512-wasm": "^1.2.0",
+    "sha256-universal": "^1.0.1",
+    "sha512-universal": "^1.0.1",
     "siphash24": "^1.0.1",
     "xsalsa20": "^1.0.0"
   },


### PR DESCRIPTION
update hash modules to provide JS fallback and make WASM modules < 4kB

new modules:
- https://github.com/chm-diederichs/sha256-universal
- https://github.com/chm-diederichs/sha512-universal