### PR TITLE
crypto_verify return booleans & add crypto_verify_64

### DIFF
--- a/crypto_aead.js
+++ b/crypto_aead.js
@@ -131,7 +131,7 @@ function crypto_aead_chacha20poly1305_ietf_decrypt_detached (m, nsec, c, mac, ad
   computed_mac.fill(0)
   slen.fill(0)
 
-  if (ret !== 0) {
+  if (!ret) {
     m.fill(0)
     throw new Error('could not verify data')
   }

--- a/crypto_onetimeauth.js
+++ b/crypto_onetimeauth.js
@@ -23,7 +23,6 @@ function crypto_onetimeauth (mac, msg, key) {
   var s = new Poly1305(key)
   s.update(msg, 0, msg.byteLength)
   s.finish(mac, 0)
-  return true
 }
 
 function crypto_onetimeauth_verify (mac, msg, key) {

--- a/crypto_onetimeauth.js
+++ b/crypto_onetimeauth.js
@@ -33,5 +33,5 @@ function crypto_onetimeauth_verify (mac, msg, key) {
 
   var tmp = new Uint8Array(16)
   crypto_onetimeauth(tmp, msg, key)
-  return crypto_verify_16(mac, 0, tmp, 0) === 0
+  return crypto_verify_16(mac, 0, tmp, 0)
 }

--- a/crypto_secretbox.js
+++ b/crypto_secretbox.js
@@ -37,7 +37,6 @@ function crypto_secretbox (c, m, n, k) {
     c.subarray(0, crypto_onetimeauth_KEYBYTES)
   )
   c.fill(0, 0, crypto_secretbox_BOXZEROBYTES)
-  return 0
 }
 
 function crypto_secretbox_open (m, c, n, k) {
@@ -94,9 +93,8 @@ function crypto_secretbox_easy (o, msg, n, k) {
   const m = new Uint8Array(crypto_secretbox_ZEROBYTES + msg.byteLength)
   const c = new Uint8Array(m.byteLength)
   m.set(msg, crypto_secretbox_ZEROBYTES)
-  if (crypto_secretbox(c, m, n, k) === false) return false
+  crypto_secretbox(c, m, n, k)
   o.set(c.subarray(crypto_secretbox_BOXZEROBYTES))
-  return true
 }
 
 function crypto_secretbox_open_easy (msg, box, n, k) {

--- a/crypto_sign.js
+++ b/crypto_sign.js
@@ -242,16 +242,16 @@ function unpackneg (r, p) {
 
   S(chk, r[0])
   M(chk, chk, den)
-  if (neq25519(chk, num)) M(r[0], r[0], I)
+  if (!neq25519(chk, num)) M(r[0], r[0], I)
 
   S(chk, r[0])
   M(chk, chk, den)
-  if (neq25519(chk, num)) return -1
+  if (!neq25519(chk, num)) return false
 
   if (par25519(r[0]) === (p[31] >> 7)) Z(r[0], gf0, r[0])
 
   M(r[3], r[0], r[1])
-  return 0
+  return true
 }
 
 /* eslint-disable no-unused-vars */
@@ -270,7 +270,7 @@ function crypto_sign_open (msg, sm, pk) {
   mlen = -1
   if (n < 64) return false
 
-  if (unpackneg(q, pk)) return false
+  if (!unpackneg(q, pk)) return false
 
   for (i = 0; i < n; i++) m[i] = sm[i]
   for (i = 0; i < 32; i++) m[i + 32] = pk[i]
@@ -283,7 +283,7 @@ function crypto_sign_open (msg, sm, pk) {
   pack(t, p)
 
   n -= 64
-  if (crypto_verify_32(sm, 0, t, 0)) {
+  if (!crypto_verify_32(sm, 0, t, 0)) {
     for (i = 0; i < n; i++) m[i] = 0
     return false
     // throw new Error('crypto_sign_open failed')

--- a/crypto_verify.js
+++ b/crypto_verify.js
@@ -1,7 +1,8 @@
 /* eslint-disable camelcase */
 module.exports = {
   crypto_verify_16,
-  crypto_verify_32
+  crypto_verify_32,
+  crypto_verify_64
 }
 
 function vn (x, xi, y, yi, n) {
@@ -16,9 +17,13 @@ Object.defineProperty(module.exports, 'vn', {
 })
 
 function crypto_verify_16 (x, xi, y, yi) {
-  return vn(x, xi, y, yi, 16)
+  return vn(x, xi, y, yi, 16) === 0
 }
 
 function crypto_verify_32 (x, xi, y, yi) {
-  return vn(x, xi, y, yi, 32)
+  return vn(x, xi, y, yi, 32) === 0
+}
+
+function crypto_verify_64 (x, xi, y, yi) {
+  return vn(x, xi, y, yi, 64) === 0
 }


### PR DESCRIPTION
`crypto_verify` methods are used in `crypto_sign.js` and `crypto_aead.js`, however only once is it checked `!== 0`.