### PR TITLE
Remove unused argument from crypto_kx

### DIFF
--- a/crypto_kx.js
+++ b/crypto_kx.js
@@ -12,7 +12,7 @@ function crypto_kx_keypair (pk, sk) {
   assert(pk.byteLength === crypto_kx_PUBLICKEYBYTES, "pk must be 'crypto_kx_PUBLICKEYBYTES' bytes")
   assert(sk.byteLength === crypto_kx_SECRETKEYBYTES, "sk must be 'crypto_kx_SECRETKEYBYTES' bytes")
 
-  randombytes_buf(sk, crypto_kx_SECRETKEYBYTES)
+  randombytes_buf(sk)
   return crypto_scalarmult_base(pk, sk)
 }
 


### PR DESCRIPTION
Problem: randombytes_buf uses the size of the buffer as the number of
bytes to output, so we don't need to add an argument about the number of
bytes we want.

Solution: Remove unused argument and use buffer size assertion to be
sure that we're producing the correct number of random bytes.