### PR TITLE
Fix crypto_secretbox return value

### DIFF
--- a/crypto_secretbox.js
+++ b/crypto_secretbox.js
@@ -37,7 +37,7 @@ function crypto_secretbox (c, m, n, k) {
     c.subarray(0, crypto_onetimeauth_KEYBYTES)
   )
   c.fill(0, 0, crypto_secretbox_BOXZEROBYTES)
-  return 0
+  return true
 }
 
 function crypto_secretbox_open (m, c, n, k) {


### PR DESCRIPTION
Problem: This doesn't cause a bug, when crypto_secretbox returns an
integer (`0`) then the check on line 97 always fails because it checks
whether the return value triple-equals `false`.

Solution: Change crypto_secretbox so that it returns booleans rather
than integers, which gives us the ability to make the check on line 97
fail (if we ever return anything other than `true`).