### PR TITLE
BREAKING: Rename '_ready' suffix to '_wasm_ready'

### DIFF
--- a/crypto_generichash.js
+++ b/crypto_generichash.js
@@ -16,7 +16,7 @@ module.exports.crypto_generichash = function (output, input, key) {
   blake2b(output.length, key).update(input).final(output)
 }
 
-module.exports.crypto_generichash_ready = blake2b.ready
+module.exports.crypto_generichash_wasm_ready = blake2b.ready
 
 module.exports.crypto_generichash_batch = function (output, inputArray, key) {
   var ctx = blake2b(output.length, key)


### PR DESCRIPTION
When looking through each of the extra methods exposed by this module I
noticed lots of 'wasm' mentions, but since this method doesn't mention
wasm it wasn't clear to me why this extra method was being exposed.

This commit is a breaking change that renames crypto_generichash_ready
to crypto_generichash_wasm_ready, which feels more clear to me.