### PR TITLE
BREAKING: Remove unused exported methods

### DIFF
--- a/crypto_box.js
+++ b/crypto_box.js
@@ -10,8 +10,6 @@ const assert = require('nanoassert')
 const crypto_box_PUBLICKEYBYTES = 32
 const crypto_box_SECRETKEYBYTES = 32
 const crypto_box_NONCEBYTES = 24
-const crypto_box_ZEROBYTES = 32
-const crypto_box_BOXZEROBYTES = 16
 const crypto_box_SEALBYTES = 48
 const crypto_box_SEEDBYTES = 32
 const crypto_box_BEFORENMBYTES = 32
@@ -24,11 +22,8 @@ module.exports = {
   crypto_box_PUBLICKEYBYTES,
   crypto_box_SECRETKEYBYTES,
   crypto_box_NONCEBYTES,
-  crypto_box_ZEROBYTES,
-  crypto_box_BOXZEROBYTES,
   crypto_box_SEALBYTES,
-  crypto_box_SEEDBYTES,
-  crypto_box_BEFORENMBYTES
+  crypto_box_SEEDBYTES
 }
 
 function crypto_box_keypair (pk, sk) {

--- a/crypto_secretbox.js
+++ b/crypto_secretbox.js
@@ -10,16 +10,12 @@ const crypto_secretbox_BOXZEROBYTES = 16
 const crypto_secretbox_MACBYTES = 16
 
 module.exports = {
-  crypto_secretbox,
-  crypto_secretbox_open,
   crypto_secretbox_detached,
   crypto_secretbox_open_detached,
   crypto_secretbox_easy,
   crypto_secretbox_open_easy,
   crypto_secretbox_KEYBYTES,
   crypto_secretbox_NONCEBYTES,
-  crypto_secretbox_ZEROBYTES,
-  crypto_secretbox_BOXZEROBYTES,
   crypto_secretbox_MACBYTES
 }
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@
 forward(require('./randombytes'))
 forward(require('./memory'))
 forward(require('./helpers'))
-forward(require('./crypto_verify'))
 forward(require('./crypto_box'))
 forward(require('./crypto_generichash'))
 forward(require('./crypto_hash'))


### PR DESCRIPTION
Some methods have accidentally been exported, even though they don't
appear in Sodium-Native, which gives Sodium-JavaScript a slightly
different API. The goal is to have the same API except:

- Wasm methods
- _instance methods (legacy)

This commit removes the extra methods so that we have API parity with
Sodium-Native (with the above two exceptions).