### PR TITLE
RN: Detect if window.close is defined

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,3 +1,3 @@
 require('sodium-test')(require('.'))
 
-if (typeof window !== 'undefined') window.close()
+if ((typeof window !== 'undefined') && window.close) window.close()


### PR DESCRIPTION
This is needed for react-native because it defines a `window` global, but it doesn't have a `window.close` method.