### PR TITLE
Return 0 from crypto_sign_keypair for unit tests

### DIFF
--- a/crypto_sign.js
+++ b/crypto_sign.js
@@ -145,6 +145,8 @@ function crypto_sign_keypair (pk, sk, seeded) {
   pack(pk, p)
 
   for (i = 0; i < 32; i++) sk[i + 32] = pk[i]
+
+  return 0
 }
 
 function crypto_sign_seed_keypair (pk, sk, seed) {


### PR DESCRIPTION
Noticed that tests were failing on [this line](https://github.com/consento-org/sodium-test/blob/master/crypto_sign.js#L153) in sodium-test due to crypto_sign_keypair and crypto_sign_seed_keypair not returning `0`