### PR TITLE
Support environments without MessageChannel or worker_threads

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -14,8 +14,8 @@ function sodium_malloc (n) {
 
 const sink = MessageChannel ? new MessageChannel() : null
 function sodium_free (n) {
-  if (!sink) return
   sodium_memzero(n)
+  if (!sink) return
   sink.port1.postMessage(n.buffer, [n.buffer])
 }
 

--- a/memory.js
+++ b/memory.js
@@ -1,13 +1,20 @@
 /* eslint-disable camelcase */
 var MessageChannel = global.MessageChannel
-if (MessageChannel == null) ({ MessageChannel } = require('worker' + '_threads'))
+if (MessageChannel == null) {
+  try {
+    ({ MessageChannel } = require('worker' + '_threads'))
+  } catch (e) {
+    // Must not be supported
+  }
+}
 
 function sodium_malloc (n) {
   return new Uint8Array(n)
 }
 
-const sink = new MessageChannel()
+const sink = MessageChannel ? new MessageChannel() : null
 function sodium_free (n) {
+  if (!sink) return
   sodium_memzero(n)
   sink.port1.postMessage(n.buffer, [n.buffer])
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     ]
   },
   "browser": {
-    "crypto": false
+    "crypto": false,
+    "worker_threads": false
   },
   "react-native": {
     "crypto": "crypto"

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "crypto": false,
     "worker_threads": false
   },
-  "react-native": {
-    "crypto": "crypto"
-  },
   "scripts": {
     "pretest": "standard",
     "test": "node test.js",


### PR DESCRIPTION
Part of #48 

Fixes #47 

This doesn't provide an alternative implementation for sodium_free, but it prevents runtime and compile-time errors in RN and node 10