### PR TITLE
Remove "react-native" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "crypto": false,
     "worker_threads": false
   },
-  "react-native": {
-    "crypto": "crypto"
-  },
   "scripts": {
     "pretest": "standard",
     "test": "node test.js",


### PR DESCRIPTION
This field isn't adding anything at the moment, and it actually breaks things by pointing at an unresolvable module.