### PR TITLE
fix: Not sure why this is here, but it breaks my webpack build.

### DIFF
--- a/randombytes.js
+++ b/randombytes.js
@@ -20,12 +20,6 @@ var randombytes = (function () {
 
   if (crypto && crypto.getRandomValues) return browserBytes
 
-  if (require != null) {
-    // Node.js. Bust Browserify
-    crypto = require('cry' + 'pto')
-    if (crypto && crypto.randomBytes) return nodeBytes
-  }
-
   return noImpl
 })()
 


### PR DESCRIPTION
I didn't have a whole lot of time to investigate this today, since I'm just making a proof of concept prototype, but I became curious to know why this piece of code is here ? 

Is there another way to do this that is less hacky?

EDIT: I don't actually think this is necessary anymore if you use sodium-universal for libraries that need isomorphic support.
