### PR TITLE
`randombytes`: Replace run-time require detection

### DIFF
--- a/randombytes.js
+++ b/randombytes.js
@@ -20,7 +20,7 @@ var randombytes = (function () {
 
   if (crypto && crypto.getRandomValues) return browserBytes
 
-  if (require != null) {
+  if (typeof require === 'function') {
     // Node.js. Bust Browserify
     crypto = require('cry' + 'pto')
     if (crypto && crypto.randomBytes) return nodeBytes


### PR DESCRIPTION
Using require() as an expression leads to compile errors in webpack. This issue can be solved by guarding the use of require by the 'correct' run-time check using `typeof require`.

The issue is easy to reproduce by - for example - using libsodium-javascript from a react project.